### PR TITLE
Bug/pad

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toruslabs/torus.js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Handle communication with torus nodes",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/some.js
+++ b/src/some.js
@@ -19,6 +19,7 @@ export const Some = (promises, predicate) => {
             })
             .catch(err => log.debug('predicate', err))
             .finally(_ => {
+              log.debug('finally')
               finishedCount++
               if (finishedCount === promises.length) {
                 reject(new Error('Unable to resolve enough promises, responses: ' + JSON.stringify(resultArr)))

--- a/src/torus.js
+++ b/src/torus.js
@@ -237,7 +237,7 @@ class Torus {
   getPubKeyAsync(endpoints, { verifier, verifierId }) {
     return new Promise((resolve, reject) => {
       keyLookup(endpoints, verifier, verifierId)
-        .then(({ keyResult, errorResult }) => {
+        .then(({ keyResult, errorResult } = {}) => {
           if (errorResult) {
             return keyAssign(endpoints, undefined, verifier, verifierId).then(_ => {
               return keyLookup(endpoints, verifier, verifierId)
@@ -249,7 +249,7 @@ class Torus {
           return reject(new Error('node results do not match'))
         })
         .catch(err => log.debug('key assign', err))
-        .then(({ keyResult }) => {
+        .then(({ keyResult } = {}) => {
           if (keyResult) {
             var ethAddress = keyResult.keys[0].address
             resolve(ethAddress)

--- a/src/torus.js
+++ b/src/torus.js
@@ -11,9 +11,9 @@ import { thresholdSame, kCombinations, keyLookup, keyAssign } from './utils'
 // Implement threshold logic wrappers around public APIs
 // of Torus nodes to handle malicious node responses
 class Torus {
-  constructor({ enableLogging = false } = {}) {
+  constructor({ enableLogging = true } = {}) {
     this.ec = ec('secp256k1')
-    log.setDefaultLevel('DEBUG')
+    log.setDefaultLevel('debug')
     if (!enableLogging) log.disableAll()
   }
 
@@ -172,7 +172,10 @@ class Torus {
                 const pubKey = eccrypto.getPublic(Buffer.from(derivedPrivateKey.toString(16, 64), 'hex')).toString('hex')
                 const pubKeyX = pubKey.slice(2, 66)
                 const pubKeyY = pubKey.slice(66)
-                if (pubKeyX === thresholdPublicKey.X && pubKeyY === thresholdPublicKey.Y) {
+                if (
+                  new BN(pubKeyX, 16).cmp(new BN(thresholdPublicKey.X, 16)) === 0 &&
+                  new BN(pubKeyY, 16).cmp(new BN(thresholdPublicKey.Y, 16)) === 0
+                ) {
                   privateKey = derivedPrivateKey
                   break
                 }


### PR DESCRIPTION
Add default params for functions that do param destructuring
compare hex strings by converting them to BN first, since leading zeros are omitted in some places
