### PR TITLE
Fix issues with Some early exit

### DIFF
--- a/src/some.js
+++ b/src/some.js
@@ -1,7 +1,7 @@
 export const Some = (promises, predicate) => {
   return new Promise((resolve, reject) => {
     let finishedCount = 0
-    let resolved = false
+    const sharedState = { resolved: false }
     const resultArr = new Array(promises.length).fill(undefined)
     promises.forEach((x, index) => {
       x.then((resp) => {
@@ -10,10 +10,10 @@ export const Some = (promises, predicate) => {
       })
         .catch((_) => {})
         .finally(() => {
-          if (resolved) return
-          predicate(resultArr.slice(0))
+          if (sharedState.resolved) return
+          predicate(resultArr.slice(0), sharedState)
             .then((data) => {
-              resolved = true
+              sharedState.resolved = true
               resolve(data)
               return undefined
             })


### PR DESCRIPTION
Due to predicates in Some having async function calls, its possible that early exits dont happen

if the predicates are all started around the same time, since between the start of predicates, the first predicate will not have evaluated to completion

using sharedState, we can ensure that sync blocks of logic in the predicate can be skipped if any predicate
has run to completion