### PR TITLE
Filter complete requests if  you get an error response

### DIFF
--- a/src/torus.js
+++ b/src/torus.js
@@ -78,7 +78,15 @@ class Torus {
       */
     // send share request once k + t number of commitment requests have completed
     return Some(promiseArr, (resultArr) => {
-      const completedRequests = resultArr.filter((x) => x)
+      const completedRequests = resultArr.filter((x) => {
+        if (!x || typeof x !== 'object') {
+          return false
+        }
+        if (x.error) {
+          return false
+        }
+        return true
+      })
       if (completedRequests.length >= ~~(endpoints.length / 4) * 3 + 1) {
         return Promise.resolve(resultArr)
       }


### PR DESCRIPTION
When servers return an error response, we should just assume its a bad response and filter out that response