### PR TITLE
Update web3-utils to v1.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "json-stable-stringify": "^1.0.1",
     "loglevel": "^1.7.1",
     "memory-cache": "^0.2.0",
-    "web3-utils": "^1.3.4"
+    "web3-utils": "^1.3.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.16",


### PR DESCRIPTION
In web3-utils v1.3.6 a dep, underscore, is updated to 1.12.1 in order to patch a security vulnerability.