### PR TITLE
Fix locking and add locks for getOrSetNonce

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["toruslabs"]
+  "cSpell.words": ["Mutex", "Mutexes", "toruslabs"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,9 +216,9 @@
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.4.tgz",
-      "integrity": "sha512-OrpPZ97s+aPi6h2n1OXzdhVis1SGSsMU2aMHgLcOKfsp4/v1NWpx3CWT3lBj5eeBq9cDkPkh+YCfdF7O12uNDQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+      "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
       "dev": true,
       "requires": {
         "@babel/helper-compilation-targets": "^7.13.0",
@@ -420,9 +420,9 @@
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.0.tgz",
-      "integrity": "sha512-MLM1IOMe9aQBqMWxcRw8dcb9jlM86NIw7KA0Wri91Xkfied+dE0QuBFSBjMNvqzmS0OSIDsMNC24dBEkPUi7ew==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.4.tgz",
+      "integrity": "sha512-vGERmmhR+s7eH5Y/cp8PCVzj4XEjerq8jooMfxFdA5xVtAk9Sh4AQsrWgiErUEBjtGrBtOFKDUcWQFW4/dFwMA==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
@@ -626,13 +626,13 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.0.tgz",
-      "integrity": "sha512-nyYmIo7ZqKsY6P4lnVmBlxp9B3a96CscbLotlsNuktMHahkDwoPYEjXrZHU0Tj844Z9f1IthVxQln57mhkcExw==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.4.tgz",
+      "integrity": "sha512-/CUekqaAaZCQHleSK/9HajvcD/zdnJiKRiuUFq8ITE+0HsPzquf53cpFiqAwl/UfmJbR6n5uGPQSPdrmKOvHHg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-remap-async-to-generator": "^7.16.0",
+        "@babel/helper-remap-async-to-generator": "^7.16.4",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       }
     },
@@ -1178,16 +1178,16 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.0.tgz",
-      "integrity": "sha512-zlPf1/XFn5+vWdve3AAhf+Sxl+MVa5VlwTwWgnLx23u4GlatSRQJ3Eoo9vllf0a9il3woQsT4SK+5Z7c06h8ag==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz",
+      "integrity": "sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5",
-        "babel-plugin-polyfill-corejs2": "^0.2.3",
-        "babel-plugin-polyfill-corejs3": "^0.3.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.3",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -1284,18 +1284,18 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.0.tgz",
-      "integrity": "sha512-cdTu/W0IrviamtnZiTfixPfIncr2M1VqRrkjzZWlr1B4TVYimCFK5jkyOdP4qw2MrlKHi+b3ORj6x8GoCew8Dg==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.4.tgz",
+      "integrity": "sha512-v0QtNd81v/xKj4gNKeuAerQ/azeNn/G1B1qMLeXOcV8+4TWlD2j3NV1u8q29SDFBXx/NBq5kyEAO+0mpRgacjA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.16.0",
-        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-compilation-targets": "^7.16.3",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.0",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.2",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.16.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.16.4",
         "@babel/plugin-proposal-class-properties": "^7.16.0",
         "@babel/plugin-proposal-class-static-block": "^7.16.0",
         "@babel/plugin-proposal-dynamic-import": "^7.16.0",
@@ -1345,7 +1345,7 @@
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.0",
         "@babel/plugin-transform-new-target": "^7.16.0",
         "@babel/plugin-transform-object-super": "^7.16.0",
-        "@babel/plugin-transform-parameters": "^7.16.0",
+        "@babel/plugin-transform-parameters": "^7.16.3",
         "@babel/plugin-transform-property-literals": "^7.16.0",
         "@babel/plugin-transform-regenerator": "^7.16.0",
         "@babel/plugin-transform-reserved-words": "^7.16.0",
@@ -1358,13 +1358,19 @@
         "@babel/plugin-transform-unicode-regex": "^7.16.0",
         "@babel/preset-modules": "^0.1.5",
         "@babel/types": "^7.16.0",
-        "babel-plugin-polyfill-corejs2": "^0.2.3",
-        "babel-plugin-polyfill-corejs3": "^0.3.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.3",
-        "core-js-compat": "^3.19.0",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "core-js-compat": "^3.19.1",
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "@babel/compat-data": {
+          "version": "7.16.4",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
+          "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
+          "dev": true
+        },
         "@babel/types": {
           "version": "7.16.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
@@ -2478,13 +2484,13 @@
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.3.tgz",
-      "integrity": "sha512-NDZ0auNRzmAfE1oDDPW2JhzIMXUk+FFe2ICejmt5T4ocKgiQx3e0VCRx9NCAidcMtL2RUZaWtXnmjTCkx0tcbA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+      "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
         "semver": "^6.1.1"
       },
       "dependencies": {
@@ -2497,22 +2503,22 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.3.0.tgz",
-      "integrity": "sha512-JLwi9vloVdXLjzACL80j24bG6/T1gYxwowG44dg6HN/7aTPdyPbJJidf6ajoA3RPHHtW0j9KMrSOLpIZpAnPpg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+      "integrity": "sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
         "core-js-compat": "^3.18.0"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.3.tgz",
-      "integrity": "sha512-JVE78oRZPKFIeUqFGrSORNzQnrDwZR16oiWeGM8ZyjBn2XAT5OjP+wXx5ESuo33nUsFUEJYjtklnsKbxW5L+7g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+      "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.4"
+        "@babel/helper-define-polyfill-provider": "^0.3.0"
       }
     },
     "balanced-match": {
@@ -6220,11 +6226,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "memory-cache": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
-      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "memory-fs": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "elliptic": "^6.5.4",
     "json-stable-stringify": "^1.0.1",
     "loglevel": "^1.7.1",
-    "memory-cache": "^0.2.0",
     "web3-utils": "^1.6.1"
   },
   "devDependencies": {
@@ -38,8 +37,8 @@
     "@babel/eslint-parser": "^7.16.3",
     "@babel/eslint-plugin": "^7.14.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.16.0",
-    "@babel/plugin-transform-runtime": "^7.16.0",
-    "@babel/preset-env": "^7.16.0",
+    "@babel/plugin-transform-runtime": "^7.16.4",
+    "@babel/preset-env": "^7.16.4",
     "@babel/register": "^7.16.0",
     "@babel/runtime-corejs3": "^7.16.3",
     "@rollup/plugin-babel": "^5.3.0",

--- a/src/torus.js
+++ b/src/torus.js
@@ -3,7 +3,6 @@ import { generateJsonRPCObject, get, post, setAPIKey, setEmbedHost } from '@toru
 import BN from 'bn.js'
 import { ec as EC } from 'elliptic'
 import stringify from 'json-stable-stringify'
-import memoryCache from 'memory-cache'
 import { keccak256, toChecksumAddress } from 'web3-utils'
 
 import log from './loglevel'
@@ -22,8 +21,6 @@ class Torus {
     this.ec = new EC('secp256k1')
     this.metadataHost = metadataHost
     this.allowHost = allowHost
-    this.metadataCache = memoryCache
-    this.metadataLock = {}
     this.enableOneKey = enableOneKey
     this.serverTimeOffset = serverTimeOffset || 0 // ms
   }
@@ -190,25 +187,26 @@ class Torus {
         return Promise.resolve(resultArr)
       }
       return Promise.reject(new Error(`invalid ${JSON.stringify(resultArr)}`))
-    }).then((responses) => {
-      const promiseArrRequest = []
-      const nodeSigs = []
-      for (let i = 0; i < responses.length; i += 1) {
-        if (responses[i]) nodeSigs.push(responses[i].result)
-      }
-      for (let i = 0; i < endpoints.length; i += 1) {
-        // eslint-disable-next-line promise/no-nesting
-        const p = post(
-          endpoints[i],
-          generateJsonRPCObject('ShareRequest', {
-            encrypted: 'yes',
-            item: [{ ...verifierParams, idtoken: idToken, nodesignatures: nodeSigs, verifieridentifier: verifier, ...extraParams }],
-          })
-        ).catch((err) => log.error('share req', err))
-        promiseArrRequest.push(p)
-      }
-      return Some(promiseArrRequest, async (shareResponses, sharedState) => {
-        /*
+    })
+      .then((responses) => {
+        const promiseArrRequest = []
+        const nodeSigs = []
+        for (let i = 0; i < responses.length; i += 1) {
+          if (responses[i]) nodeSigs.push(responses[i].result)
+        }
+        for (let i = 0; i < endpoints.length; i += 1) {
+          // eslint-disable-next-line promise/no-nesting
+          const p = post(
+            endpoints[i],
+            generateJsonRPCObject('ShareRequest', {
+              encrypted: 'yes',
+              item: [{ ...verifierParams, idtoken: idToken, nodesignatures: nodeSigs, verifieridentifier: verifier, ...extraParams }],
+            })
+          ).catch((err) => log.error('share req', err))
+          promiseArrRequest.push(p)
+        }
+        return Some(promiseArrRequest, async (shareResponses, sharedState) => {
+          /*
               ShareRequestResult struct {
                 Keys []KeyAssignment
               }
@@ -226,131 +224,114 @@ class Torus {
                 Share big.Int // Or Si
               }
             */
-        // check if threshold number of nodes have returned the same user public key
-        const completedRequests = shareResponses.filter((x) => x)
-        const thresholdPublicKey = thresholdSame(
-          shareResponses.map((x) => x && x.result && x.result.keys[0].PublicKey),
-          ~~(endpoints.length / 2) + 1
-        )
-        // optimistically run lagrange interpolation once threshold number of shares have been received
-        // this is matched against the user public key to ensure that shares are consistent
-        if (completedRequests.length >= ~~(endpoints.length / 2) + 1 && thresholdPublicKey) {
-          const sharePromises = []
-          const nodeIndex = []
-          for (let i = 0; i < shareResponses.length; i += 1) {
-            if (shareResponses[i] && shareResponses[i].result && shareResponses[i].result.keys && shareResponses[i].result.keys.length > 0) {
-              shareResponses[i].result.keys.sort((a, b) => new BN(a.Index, 16).cmp(new BN(b.Index, 16)))
-              if (shareResponses[i].result.keys[0].Metadata) {
-                const metadata = {
-                  ephemPublicKey: Buffer.from(shareResponses[i].result.keys[0].Metadata.ephemPublicKey, 'hex'),
-                  iv: Buffer.from(shareResponses[i].result.keys[0].Metadata.iv, 'hex'),
-                  mac: Buffer.from(shareResponses[i].result.keys[0].Metadata.mac, 'hex'),
-                  mode: Buffer.from(shareResponses[i].result.keys[0].Metadata.mode, 'hex'),
+          // check if threshold number of nodes have returned the same user public key
+          const completedRequests = shareResponses.filter((x) => x)
+          const thresholdPublicKey = thresholdSame(
+            shareResponses.map((x) => x && x.result && x.result.keys[0].PublicKey),
+            ~~(endpoints.length / 2) + 1
+          )
+          // optimistically run lagrange interpolation once threshold number of shares have been received
+          // this is matched against the user public key to ensure that shares are consistent
+          if (completedRequests.length >= ~~(endpoints.length / 2) + 1 && thresholdPublicKey) {
+            const sharePromises = []
+            const nodeIndex = []
+            for (let i = 0; i < shareResponses.length; i += 1) {
+              if (shareResponses[i] && shareResponses[i].result && shareResponses[i].result.keys && shareResponses[i].result.keys.length > 0) {
+                shareResponses[i].result.keys.sort((a, b) => new BN(a.Index, 16).cmp(new BN(b.Index, 16)))
+                if (shareResponses[i].result.keys[0].Metadata) {
+                  const metadata = {
+                    ephemPublicKey: Buffer.from(shareResponses[i].result.keys[0].Metadata.ephemPublicKey, 'hex'),
+                    iv: Buffer.from(shareResponses[i].result.keys[0].Metadata.iv, 'hex'),
+                    mac: Buffer.from(shareResponses[i].result.keys[0].Metadata.mac, 'hex'),
+                    mode: Buffer.from(shareResponses[i].result.keys[0].Metadata.mode, 'hex'),
+                  }
+                  sharePromises.push(
+                    // eslint-disable-next-line promise/no-nesting
+                    decrypt(tmpKey, {
+                      ...metadata,
+                      ciphertext: Buffer.from(atob(shareResponses[i].result.keys[0].Share).padStart(64, '0'), 'hex'),
+                    }).catch((err) => log.debug('share decryption', err))
+                  )
+                } else {
+                  sharePromises.push(Promise.resolve(Buffer.from(shareResponses[i].result.keys[0].Share.padStart(64, '0'), 'hex')))
                 }
-                sharePromises.push(
-                  // eslint-disable-next-line promise/no-nesting
-                  decrypt(tmpKey, {
-                    ...metadata,
-                    ciphertext: Buffer.from(atob(shareResponses[i].result.keys[0].Share).padStart(64, '0'), 'hex'),
-                  }).catch((err) => log.debug('share decryption', err))
-                )
               } else {
-                sharePromises.push(Promise.resolve(Buffer.from(shareResponses[i].result.keys[0].Share.padStart(64, '0'), 'hex')))
+                sharePromises.push(Promise.resolve(undefined))
               }
-            } else {
-              sharePromises.push(Promise.resolve(undefined))
+              nodeIndex.push(new BN(indexes[i], 16))
             }
-            nodeIndex.push(new BN(indexes[i], 16))
-          }
-          const sharesResolved = await Promise.all(sharePromises)
-          if (sharedState.resolved) return undefined
+            const sharesResolved = await Promise.all(sharePromises)
+            if (sharedState.resolved) return undefined
 
-          const decryptedShares = sharesResolved.reduce((acc, curr, index) => {
-            if (curr) acc.push({ index: nodeIndex[index], value: new BN(curr) })
-            return acc
-          }, [])
-          // run lagrange interpolation on all subsets, faster in the optimistic scenario than berlekamp-welch due to early exit
-          const allCombis = kCombinations(decryptedShares.length, ~~(endpoints.length / 2) + 1)
-          let privateKey
-          for (let j = 0; j < allCombis.length; j += 1) {
-            const currentCombi = allCombis[j]
-            const currentCombiShares = decryptedShares.filter((v, index) => currentCombi.includes(index))
-            const shares = currentCombiShares.map((x) => x.value)
-            const indices = currentCombiShares.map((x) => x.index)
-            const derivedPrivateKey = this.lagrangeInterpolation(shares, indices)
-            const decryptedPubKey = getPublic(Buffer.from(derivedPrivateKey.toString(16, 64), 'hex')).toString('hex')
-            const decryptedPubKeyX = decryptedPubKey.slice(2, 66)
-            const decryptedPubKeyY = decryptedPubKey.slice(66)
-            if (
-              new BN(decryptedPubKeyX, 16).cmp(new BN(thresholdPublicKey.X, 16)) === 0 &&
-              new BN(decryptedPubKeyY, 16).cmp(new BN(thresholdPublicKey.Y, 16)) === 0
-            ) {
-              privateKey = derivedPrivateKey
-              break
+            const decryptedShares = sharesResolved.reduce((acc, curr, index) => {
+              if (curr) acc.push({ index: nodeIndex[index], value: new BN(curr) })
+              return acc
+            }, [])
+            // run lagrange interpolation on all subsets, faster in the optimistic scenario than berlekamp-welch due to early exit
+            const allCombis = kCombinations(decryptedShares.length, ~~(endpoints.length / 2) + 1)
+            let privateKey
+            for (let j = 0; j < allCombis.length; j += 1) {
+              const currentCombi = allCombis[j]
+              const currentCombiShares = decryptedShares.filter((v, index) => currentCombi.includes(index))
+              const shares = currentCombiShares.map((x) => x.value)
+              const indices = currentCombiShares.map((x) => x.index)
+              const derivedPrivateKey = this.lagrangeInterpolation(shares, indices)
+              const decryptedPubKey = getPublic(Buffer.from(derivedPrivateKey.toString(16, 64), 'hex')).toString('hex')
+              const decryptedPubKeyX = decryptedPubKey.slice(2, 66)
+              const decryptedPubKeyY = decryptedPubKey.slice(66)
+              if (
+                new BN(decryptedPubKeyX, 16).cmp(new BN(thresholdPublicKey.X, 16)) === 0 &&
+                new BN(decryptedPubKeyY, 16).cmp(new BN(thresholdPublicKey.Y, 16)) === 0
+              ) {
+                privateKey = derivedPrivateKey
+                break
+              }
             }
+            if (privateKey === undefined) {
+              throw new Error('could not derive private key')
+            }
+            return privateKey
           }
-          if (privateKey === undefined) {
-            throw new Error('could not derive private key')
-          }
-
-          let metadataNonce
-          if (this.enableOneKey) {
-            const { nonce } = await this.getNonce(thresholdPublicKey.X, thresholdPublicKey.Y, privateKey)
-            metadataNonce = new BN(nonce || '0', 16)
-          } else {
-            metadataNonce = await this.getMetadata({ pub_key_X: thresholdPublicKey.X, pub_key_Y: thresholdPublicKey.Y })
-          }
-          log.debug('> torus.js/retrieveShares', { privKey: privateKey.toString(16), metadataNonce: metadataNonce.toString(16) })
-
-          if (sharedState.resolved) return undefined
-          privateKey = privateKey.add(metadataNonce).umod(this.ec.curve.n)
-
-          const ethAddress = this.generateAddressFromPrivKey(privateKey)
-          log.debug('> torus.js/retrieveShares', { ethAddress, privKey: privateKey.toString(16) })
-
-          // return reconstructed private key and ethereum address
-          return {
-            ethAddress,
-            privKey: privateKey.toString('hex', 64),
-            metadataNonce,
-          }
-        }
-        throw new Error('invalid')
+          throw new Error('invalid')
+        })
       })
-    })
+      .then(async (returnedKey) => {
+        let privateKey = returnedKey
+        const decryptedPubKey = getPublic(Buffer.from(privateKey.toString(16, 64), 'hex')).toString('hex')
+        const decryptedPubKeyX = decryptedPubKey.slice(2, 66)
+        const decryptedPubKeyY = decryptedPubKey.slice(66)
+        let metadataNonce
+        if (this.enableOneKey) {
+          const { nonce } = await this.getNonce(decryptedPubKeyX, decryptedPubKeyY, privateKey)
+          metadataNonce = new BN(nonce || '0', 16)
+        } else {
+          metadataNonce = await this.getMetadata({ pub_key_X: decryptedPubKeyX, pub_key_Y: decryptedPubKeyY })
+        }
+        log.debug('> torus.js/retrieveShares', { privKey: privateKey.toString(16), metadataNonce: metadataNonce.toString(16) })
+
+        privateKey = privateKey.add(metadataNonce).umod(this.ec.curve.n)
+
+        const ethAddress = this.generateAddressFromPrivKey(privateKey)
+        log.debug('> torus.js/retrieveShares', { ethAddress, privKey: privateKey.toString(16) })
+
+        // return reconstructed private key and ethereum address
+        return {
+          ethAddress,
+          privKey: privateKey.toString('hex', 64),
+          metadataNonce,
+        }
+      })
   }
 
   async getMetadata(data, options) {
-    let unlock
     try {
-      const dataKey = stringify(data)
-      if (this.metadataLock[dataKey]) {
-        await this.metadataLock[dataKey]
-      } else {
-        this.metadataLock[dataKey] = new Promise((resolve) => {
-          unlock = () => {
-            this.metadataLock[dataKey] = null
-            resolve()
-          }
-        })
-      }
-      const cachedResult = this.metadataCache.get(dataKey)
-      if (cachedResult !== null) {
-        if (unlock) unlock()
-        return cachedResult
-      }
       const metadataResponse = await post(`${this.metadataHost}/get`, data, options, { useAPIKey: true })
       if (!metadataResponse || !metadataResponse.message) {
-        this.metadataCache.put(dataKey, new BN(0), 60000)
-        if (unlock) unlock()
         return new BN(0)
       }
-      this.metadataCache.put(dataKey, new BN(metadataResponse.message, 16), 60000)
-      if (unlock) unlock()
       return new BN(metadataResponse.message, 16) // nonce
     } catch (error) {
       log.error('get metadata error', error)
-      if (unlock) unlock()
       return new BN(0)
     }
   }
@@ -372,7 +353,6 @@ class Torus {
 
   async setMetadata(data, options) {
     try {
-      this.metadataCache.del(stringify({ pub_key_X: data.pub_key_X, pub_key_Y: data.pub_key_Y }))
       const metadataResponse = await post(`${this.metadataHost}/set`, data, options, { useAPIKey: true })
       return metadataResponse.message // IPFS hash
     } catch (error) {
@@ -525,34 +505,7 @@ class Torus {
   }
 
   async getNonce(X, Y, privKey) {
-    // Adding a mutex here
-    let unlock
-    try {
-      const dataKey = privKey.toString(16) || `${X}-${Y}`
-      if (this.metadataLock[dataKey]) {
-        await this.metadataLock[dataKey]
-      } else {
-        this.metadataLock[dataKey] = new Promise((resolve) => {
-          unlock = () => {
-            this.metadataLock[dataKey] = null
-            resolve()
-          }
-        })
-      }
-      const cachedResult = this.metadataCache.get(dataKey)
-      if (cachedResult !== null) {
-        if (unlock) unlock()
-        return cachedResult
-      }
-      const metadataResponse = await this.getOrSetNonce(X, Y, privKey, true)
-      this.metadataCache.put(dataKey, metadataResponse, 60000)
-      if (unlock) unlock()
-      return metadataResponse // { nonce }
-    } catch (error) {
-      log.error('get metadata error', error)
-      if (unlock) unlock()
-      return { nonce: new BN(0) }
-    }
+    return this.getOrSetNonce(X, Y, privKey, true)
   }
 
   getPostboxKeyFrom1OutOf1(privKey, nonce) {


### PR DESCRIPTION
we add lock for getNonce because during reconstruction of private key, it calls getOrSetNonce for the same key (n/2 + 1) times.
The result would be the same in all cases and calls should be optimized