### PR TITLE
fix key assign error msg to retry

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,6 +99,8 @@ export const keyAssign = async ({
   let initialPoint: number | undefined;
   if (lastPoint === undefined) {
     nodeNum = Math.floor(Math.random() * endpoints.length);
+    // nodeNum = endpoints.indexOf("https://torus-node.ens.domains/jrpc");
+    log.info("keyassign", nodeNum, endpoints[nodeNum]);
     initialPoint = nodeNum;
   } else {
     nodeNum = lastPoint % endpoints.length;
@@ -134,10 +136,13 @@ export const keyAssign = async ({
       }
     );
   } catch (error) {
-    log.error(error);
+    log.error(error.status, error.message, error, "key assign error");
     const acceptedErrorMsgs = [
       // Slow node
       "Timed out",
+      "Failed to fetch",
+      "cancelled",
+      "NetworkError when attempting to fetch resource.",
       // Happens when the node is not reachable (dns issue etc)
       "TypeError: Failed to fetch", // All except iOS and Firefox
       "TypeError: cancelled", // iOS

--- a/test/index.html
+++ b/test/index.html
@@ -9,13 +9,14 @@
     const fetchNodeDetails = new FetchNodeDetails.default();
     const torus = new TorusUtils.default({ network: "mainnet" });
     const verifier = "google"; // any verifier
-    const verifierId = "hello@tor.us"; // any verifier id
+    const verifierId = `${Math.random().toString(36).substring(2)}@tor.us`; // any verifier id
     fetchNodeDetails
       .getNodeDetails({ verifier, verifierId })
       .then(function ({ torusNodeEndpoints, torusNodePub }) {
         console.log(arguments);
         return torus.getPublicAddress(torusNodeEndpoints, torusNodePub, { verifier, verifierId });
       })
-      .then((publicAddress) => console.log(publicAddress));
+      .then((publicAddress) => console.log(publicAddress))
+      .catch(console.error);
   </script>
 </body>


### PR DESCRIPTION
the error messages used previously to retry the key assign changed in the latest browser versions. So, we have to update the catch error msgs to do proper retry.
Fixes https://torus.sentry.io/issues/3877904803/events/4d960caa23474888be35983a6244a681/?project=5708618