### PR TITLE
make result normalization compatible to server changes and fix node indexes

### DIFF
--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -8,15 +8,19 @@ import { EciesHex, VerifierLookupResponse } from "../interfaces";
 // like created_at field might vary and nonce_data might not be returned by all nodes because
 // of the metadata implementation in sapphire.
 export const normalizeKeysResult = (result: VerifierLookupResponse) => {
+  const finalResult: Pick<VerifierLookupResponse, "keys"> = {
+    keys: [],
+  };
   if (result && result.keys && result.keys.length > 0) {
-    result.keys.forEach((key) => {
-      // created_at can different for each node
-      delete key.created_at;
-      // nonce_data response is not guaranteed from all nodes so not including it in threshold check.
-      delete key.nonce_data;
+    finalResult.keys = result.keys.map((key) => {
+      return {
+        pub_key_X: key.pub_key_X,
+        pub_key_Y: key.pub_key_Y,
+        address: key.address,
+      };
     });
   }
-  return result;
+  return finalResult;
 };
 
 export const kCombinations = (s: number | number[], k: number): number[][] => {

--- a/src/helpers/nodeUtils.ts
+++ b/src/helpers/nodeUtils.ts
@@ -39,6 +39,7 @@ export const GetPubKeyOrKeyAssign = async (
         verifier_id: verifierId.toString(),
         extended_verifier_id: extendedVerifierId,
         one_key_flow: true,
+        fetch_node_index: true,
       }),
       null,
       { logTracingHeader: config.logRequestTracing }
@@ -67,17 +68,21 @@ export const GetPubKeyOrKeyAssign = async (
       lookupPubKeys.map((x2) => x2 && x2.error),
       ~~(endpoints.length / 2) + 1
     );
+
     const keyResult = thresholdSame(
       lookupPubKeys.map((x3) => x3 && normalizeKeysResult(x3.result)),
       ~~(endpoints.length / 2) + 1
     );
 
-    if (keyResult && keyResult.node_index) {
-      nodeIndexes.push(keyResult.node_index);
-    }
-
     // nonceResult must exist except for extendedVerifierId along with keyResult
     if ((keyResult && (nonceResult || extendedVerifierId)) || errorResult) {
+      if (keyResult) {
+        lookupResults.forEach((x1) => {
+          if (x1 && x1.result?.node_index) {
+            nodeIndexes.push(x1.result.node_index);
+          }
+        });
+      }
       return Promise.resolve({ keyResult, nodeIndexes, errorResult, nonceResult });
     }
     return Promise.reject(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -71,7 +71,7 @@ export interface JRPCResponse<T> {
 }
 
 export interface KeyLookupResult {
-  keyResult: VerifierLookupResponse;
+  keyResult: Pick<VerifierLookupResponse, "keys">;
   nodeIndexes: number[];
   errorResult: JRPCResponse<VerifierLookupResponse>["error"];
   nonceResult?: GetOrSetNonceResult;


### PR DESCRIPTION
- Return only used fields from normalize function, so that new fields from server won't break existing sdk versions
- Return node indexes correctly from getPubkeyOrKeyAssign function