### PR TITLE
Fix Buffer.from usage with hexadecimal strings

### DIFF
--- a/src/Point.ts
+++ b/src/Point.ts
@@ -19,7 +19,7 @@ class Point {
   encode(enc: string): Buffer {
     switch (enc) {
       case "arr":
-        return Buffer.concat([Buffer.from("0x04", "hex"), Buffer.from(this.x.toString("hex"), "hex"), Buffer.from(this.y.toString("hex"), "hex")]);
+        return Buffer.concat([Buffer.from("04", "hex"), Buffer.from(this.x.toString("hex"), "hex"), Buffer.from(this.y.toString("hex"), "hex")]);
       case "elliptic-compressed": {
         const key = this.ecCurve.keyFromPublic({ x: this.x.toString("hex", 64), y: this.y.toString("hex", 64) }, "hex");
         return Buffer.from(key.getPublic(true, "hex"));


### PR DESCRIPTION
`Buffer.from` does not support `0x` prefix in hexadecimal strings. In Node CLI:

    > Buffer.from("0x04", "hex")
    <Buffer >
    > Buffer.from("0x04", "hex").length
    0

Use `"04"` without the prefix to really add byte `04` to the return value of `Point.encode`.