### PR TITLE
Improve key lookup

### DIFF
--- a/src/helpers/nodeUtils.ts
+++ b/src/helpers/nodeUtils.ts
@@ -114,7 +114,7 @@ export const GetPubKeyOrKeyAssign = async (params: {
       }
 
       const serverTimeOffset = keyResult ? calculateMedian(serverTimeOffsets) : 0;
-      return Promise.resolve({ keyResult, serverTimeOffset, nodeIndexes, errorResult, nonceResult });
+      return Promise.resolve({ keyResult, serverTimeOffset, nodeIndexes, errorResult, nonceResult, lookupResults });
     }
     return Promise.reject(
       new Error(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -86,6 +86,7 @@ export interface KeyLookupResult {
   serverTimeOffset: number;
   errorResult: JRPCResponse<VerifierLookupResponse>["error"];
   nonceResult?: GetOrSetNonceResult;
+  lookupResults: (JRPCResponse<VerifierLookupResponse> | void)[];
 }
 
 export interface SignerResponse {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "@toruslabs/config/tsconfig.default.json",
   "include": ["src", "test"],
+  "esModuleInterop": true,
   "compilerOptions": {}
 }


### PR DESCRIPTION
This PR adds two improvements:

1. when doing a `legacyKeyLookup` on saphire network, the call was failing with a `Unable to resolve enough promises.` error, because each node returned a different `key_index` for the given key, as opposed to the legacy network, where the key indexes were apparently the same across all queried nodes

2. when doing the `GetPubKeyOrKeyAssign` call I exposed the raw lookup results because sometimes it may be convenient to be able to read otherwise hidden info like when was the key created