### PR TITLE
fix error msg verbosity

### DIFF
--- a/src/some.ts
+++ b/src/some.ts
@@ -10,7 +10,11 @@ export class SomeError<T> extends Error {
   predicate: string;
 
   constructor({ errors, responses, predicate }: { errors: Error[]; responses: T[]; predicate: string }) {
-    super("Unable to resolve enough promises.");
+    const message = `Unable to resolve enough promises. 
+      ${errors.length} errors: ${errors.map((x) => x?.message || x).join(", ")}, 
+      ${responses.length} responses,
+      predicate error: ${predicate}`;
+    super(message);
     this.errors = errors;
     this.responses = responses;
     this.predicate = predicate;

--- a/src/some.ts
+++ b/src/some.ts
@@ -21,9 +21,10 @@ export class SomeError<T> extends Error {
   }
 
   get message() {
-    return `${super.message}. ${this.errors.length} errors: ${this.errors.map((x) => x.message || x).join(", ")} and ${
+    return `${super.message}. errors: ${this.errors.map((x) => x?.message || x).join(", ")} and ${
       this.responses.length
-    } responses: ${JSON.stringify(this.responses)}`;
+    } responses: ${JSON.stringify(this.responses)},
+      predicate error: ${this.predicate}`;
   }
 
   toString() {

--- a/src/some.ts
+++ b/src/some.ts
@@ -11,7 +11,7 @@ export class SomeError<T> extends Error {
 
   constructor({ errors, responses, predicate }: { errors: Error[]; responses: T[]; predicate: string }) {
     const message = `Unable to resolve enough promises. 
-      ${errors.length} errors: ${errors.map((x) => x?.message || x).join(", ")}, 
+      errors: ${errors.map((x) => x?.message || x).join(", ")}, 
       ${responses.length} responses,
       predicate error: ${predicate}`;
     super(message);


### PR DESCRIPTION
- currently it only logs "Unable to resolve promises as error msg in most of the cases, which makes it super hard to debug errors
- This pr fixes error class msg assignement

Screenshot shows how it will improve error msg logs now.

<img width="922" alt="Screenshot 2024-05-08 at 5 21 36 PM" src="https://github.com/torusresearch/torus.js/assets/14052374/6724350e-1f82-4897-b8ad-a0f2953abd94">
