### PR TITLE
remove log.enableAll();

### DIFF
--- a/src/loglevel.ts
+++ b/src/loglevel.ts
@@ -1,6 +1,5 @@
 import loglevel from "loglevel";
 
 const log = loglevel.getLogger("torus.js");
-log.enableAll();
 
 export default log;


### PR DESCRIPTION
Previously, logging all levels has been enabled as default, I think unintentionally. This changes the behavior to have the logging at the default level at initialization.