### PR TITLE
fix decryption key padding for ed25519

### DIFF
--- a/src/helpers/metadataUtils.ts
+++ b/src/helpers/metadataUtils.ts
@@ -214,8 +214,11 @@ export const decryptSeedData = async (seedBase64: string, finalUserKey: BN) => {
   const seedUtf8 = Buffer.from(seedBase64, "base64").toString("utf-8");
   const seedJson = JSON.parse(seedUtf8) as EncryptedSeed;
   const bufferMetadata = { ...encParamsHexToBuf(seedJson.metadata), mode: "AES256" };
-  const bufferKey = decryptionKey.scalar.toArrayLike(Buffer);
-  const decText = await decrypt(bufferKey, {
+  const paddedDecryptionKey = Buffer.from(decryptionKey.scalar.toString("hex", 64), "hex");
+  if (paddedDecryptionKey.length < 32) {
+    throw new Error(`decryption Key length must be less than 32. got ${paddedDecryptionKey.length}`);
+  }
+  const decText = await decrypt(paddedDecryptionKey, {
     ...bufferMetadata,
     ciphertext: Buffer.from(seedJson.enc_text, "hex"),
   });

--- a/src/helpers/metadataUtils.ts
+++ b/src/helpers/metadataUtils.ts
@@ -35,8 +35,8 @@ export const getSecpKeyFromEd25519 = (
 
   const secpKeyPair = secp256k1Curve.keyFromPrivate(bufferKey);
 
-  if (bufferKey.length < 32) {
-    throw new Error(`Key length must be less than 32. got ${bufferKey.length}`);
+  if (bufferKey.length !== 32) {
+    throw new Error(`Key length must be equal to 32. got ${bufferKey.length}`);
   }
   return {
     scalar: secpKeyPair.getPrivate(),
@@ -215,8 +215,8 @@ export const decryptSeedData = async (seedBase64: string, finalUserKey: BN) => {
   const seedJson = JSON.parse(seedUtf8) as EncryptedSeed;
   const bufferMetadata = { ...encParamsHexToBuf(seedJson.metadata), mode: "AES256" };
   const paddedDecryptionKey = Buffer.from(decryptionKey.scalar.toString("hex", 64), "hex");
-  if (paddedDecryptionKey.length < 32) {
-    throw new Error(`decryption Key length must be less than 32. got ${paddedDecryptionKey.length}`);
+  if (paddedDecryptionKey.length !== 32) {
+    throw new Error(`decryption Key length must be equal to 32. got ${paddedDecryptionKey.length}`);
   }
   const decText = await decrypt(paddedDecryptionKey, {
     ...bufferMetadata,

--- a/src/helpers/metadataUtils.ts
+++ b/src/helpers/metadataUtils.ts
@@ -214,11 +214,8 @@ export const decryptSeedData = async (seedBase64: string, finalUserKey: BN) => {
   const seedUtf8 = Buffer.from(seedBase64, "base64").toString("utf-8");
   const seedJson = JSON.parse(seedUtf8) as EncryptedSeed;
   const bufferMetadata = { ...encParamsHexToBuf(seedJson.metadata), mode: "AES256" };
-  const paddedDecryptionKey = Buffer.from(decryptionKey.scalar.toString("hex", 64), "hex");
-  if (paddedDecryptionKey.length !== 32) {
-    throw new Error(`decryption Key length must be equal to 32. got ${paddedDecryptionKey.length}`);
-  }
-  const decText = await decrypt(paddedDecryptionKey, {
+  const bufferKey = decryptionKey.scalar.toArrayLike(Buffer, "be", 32);
+  const decText = await decrypt(bufferKey, {
     ...bufferMetadata,
     ciphertext: Buffer.from(seedJson.enc_text, "hex"),
   });


### PR DESCRIPTION
Added padding to decryption key which is used to decrypt ed25519 seed.

## Motivation and Context
Saw some e2e test failing randomly, found out its happening because of unpadded key.
Jira Link:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
